### PR TITLE
add static analysis tools and runners, update README

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,10 @@ group :development do
 
   # Remove the following if your server does not use RVM
   gem 'capistrano-rvm'
+
+  gem 'brakeman', require: false
+  gem 'bundler-audit', require: false
+  gem 'rubocop', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,8 +41,13 @@ GEM
     airbrussh (1.1.1)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (7.1.4)
+    ast (2.3.0)
     bcrypt (3.1.11)
+    brakeman (3.4.1)
     builder (3.2.2)
+    bundler-audit (0.5.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     capistrano (3.6.1)
       airbrussh (>= 1.0.0)
       capistrano-harrow
@@ -110,6 +115,9 @@ GEM
     nio4r (1.2.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
+    parser (2.3.1.4)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -150,6 +158,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.1.0)
     rake (11.3.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
@@ -171,6 +180,13 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    rubocop (0.45.0)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     slop (3.6.0)
     spring (2.0.0)
       activesupport (>= 4.2)
@@ -192,6 +208,7 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unicode-display_width (1.1.1)
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -200,6 +217,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  brakeman
+  bundler-audit
   capistrano
   capistrano-bundler
   capistrano-passenger (>= 0.1.1)
@@ -221,10 +240,11 @@ DEPENDENCIES
   rails (~> 5.0.0, >= 5.0.0.1)
   rails-controller-testing (~> 1.0.1)
   rspec-rails (>= 3.5.0)
+  rubocop
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
   tzinfo-data
 
 BUNDLED WITH
-   1.10.6
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ Ensure that you export the following enviroment variables before running the app
 
 * AUTH0_CLIENT_ID
 * AUTH0_CLIENT_SECRET
+* AUTH0_DOMAIN
+* AUTH0_CALLBACK_URL
 

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -1,0 +1,16 @@
+namespace :brakeman do
+  desc 'Run Brakeman'
+  task :run, :output_files do |t, args|
+    require 'brakeman'
+
+    files = args[:output_files].split(' ') if args[:output_files]
+    Brakeman.run app_path: '.', output_files: files, print_report: true
+  end
+
+  desc 'Check your code with Brakeman'
+  task :check do
+    require 'brakeman'
+    result = Brakeman.run app_path: '.', print_report: true
+    exit Brakeman::Warnings_Found_Exit_Code unless result.filtered_warnings.empty?
+  end
+end

--- a/lib/tasks/bundle_audit.rake
+++ b/lib/tasks/bundle_audit.rake
@@ -1,0 +1,23 @@
+require 'bundler/audit/cli'
+
+namespace :bundle_audit do
+  desc 'Update bundle-audit database'
+  task :update do
+    Bundler::Audit::CLI.new.update
+  end
+
+  desc 'Check gems for vulns using bundle-audit'
+  task :check do
+    Bundler::Audit::CLI.new.check
+  end
+
+  desc 'Update vulns database and check gems using bundle-audit'
+  task :run do
+    Rake::Task['bundle_audit:update'].invoke
+    Rake::Task['bundle_audit:check'].invoke
+  end
+end
+
+task :bundle_audit do
+  Rake::Task['bundle_audit:run'].invoke
+end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,0 +1,19 @@
+# Remove the Rails defaults.
+Rake::Task['test:db'].clear
+Rake::Task['test'].clear
+
+namespace :test do
+  desc 'Run all tests'
+  task all: :environment do
+    Rake::Task['bundle_audit'].invoke
+    Rake::Task['brakeman:run'].invoke
+    Rake::Task['spec'].invoke
+  end
+end
+
+task :test do
+  Rake::Task['test:all'].invoke
+end
+
+# Running `rake` should run all my tests.
+task default: :test


### PR DESCRIPTION
This adds a few static analysis tools to the project. Rubocop, Brakeman, and Bundler Audit. Rubocop performs checks against the Ruby community style guide. Brakeman and Bundler Audit perform checks for Rails security vulnerabilities and Rubygem security auditing, respectively. There are rake tasks to run all of these independently. Additionally, there is a rake task to overwrite the default rake task to hook in brakeman and bundler-audit scans after executing the specs.